### PR TITLE
Add tooling to mirror smithery.ai static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Smithery.ai Mirror Instructions
+
+This repository provides instructions and tooling to clone the static front-end of [smithery.ai](https://smithery.ai).
+
+> **Note:** Direct mirroring of the site from within this development environment is blocked by a network proxy. The provided script must be executed from an environment with unrestricted internet access.
+
+## Contents
+
+- `scripts/download_site.sh` – Shell script that uses `wget` to mirror the website.
+- `docs/USAGE.md` – Step-by-step usage guide.
+
+## Getting Started
+
+1. Ensure you have `wget` installed.
+2. Run `./scripts/download_site.sh` from a machine with external network access.
+3. The mirrored site will be placed under `mirror/smithery.ai`.
+
+## License
+
+This repository only contains tooling and documentation. Respect the terms of service and robots.txt of smithery.ai before mirroring their content.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,41 @@
+# Mirroring smithery.ai
+
+This guide explains how to replicate the publicly accessible static assets of [smithery.ai](https://smithery.ai) with the provided tooling.
+
+## Prerequisites
+
+- A Unix-like environment (Linux or macOS).
+- `wget` installed (`brew install wget` on macOS, `apt-get install wget` on Debian/Ubuntu).
+- Internet access that allows outbound HTTPS traffic without proxy restrictions.
+
+## Steps
+
+1. Clone this repository:
+
+   ```bash
+   git clone <this-repo-url>
+   cd <this-repo>
+   ```
+
+2. Run the download script:
+
+   ```bash
+   ./scripts/download_site.sh
+   ```
+
+   - Pass a custom output directory as the first argument if desired: `./scripts/download_site.sh /path/to/output`.
+
+3. Verify the mirrored content:
+
+   ```bash
+   ls mirror/smithery.ai
+   ```
+
+## Troubleshooting
+
+- **Proxy errors:** If you encounter `Proxy tunneling failed: Forbidden`, run the script from a network without an intercepting proxy.
+- **SSL errors:** Ensure `wget` supports modern TLS protocols (`wget --version`).
+
+## Disclaimer
+
+This process mirrors only the static assets publicly served by smithery.ai. It does not reproduce any server-side functionality or private content. Respect the website's terms of service and robots.txt directives.

--- a/scripts/download_site.sh
+++ b/scripts/download_site.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${1:-mirror/smithery.ai}"
+SITE_URL="https://smithery.ai/"
+
+mkdir -p "${OUTPUT_DIR}"
+
+wget \
+  --mirror \
+  --convert-links \
+  --adjust-extension \
+  --page-requisites \
+  --no-parent \
+  --directory-prefix="${OUTPUT_DIR}" \
+  "${SITE_URL}"


### PR DESCRIPTION
## Summary
- add repository README describing the mirroring tooling and network limitations
- provide a wget-based script for mirroring smithery.ai into a local directory
- document usage steps and troubleshooting guidance for running the script outside the restricted environment

## Testing
- not run (smithery.ai is inaccessible behind the current environment's proxy)


------
https://chatgpt.com/codex/tasks/task_b_68d8c40af7ec8326b01ec85ab813295f

## Summary by Sourcery

Add wget-based tooling and documentation to mirror the smithery.ai static site locally

New Features:
- Add scripts/download_site.sh for mirroring smithery.ai with wget

Documentation:
- Add README.md outlining repository contents and usage notes
- Add docs/USAGE.md with detailed prerequisites, steps, and troubleshooting guidance for the mirroring process